### PR TITLE
Regenerate TOCs with Vim-Markdown-TOC

### DIFF
--- a/applying_to_uol/README.md
+++ b/applying_to_uol/README.md
@@ -8,13 +8,17 @@ behind applying in a concise and clear way so you know exactly what to
 expect when you do it yourself.
 
 ## Table of Contents
+<!-- vim-markdown-toc GFM -->
+
 * [Administrative Information: Admissions Process and Requirements](#administrative-information-admissions-process-and-requirements)
-  * [English Requirements (for Non-English Speaking Countries)](#english-requirements-for-non-english-speaking-countries)
-  * [Documents to Prepare for Application](#documents-and-statement-to-prepare-for-application)
+    * [English Requirements for Non-English Speaking Countries](#english-requirements-for-non-english-speaking-countries)
+    * [Documents and Statement to Prepare for Application](#documents-and-statement-to-prepare-for-application)
 * [Application Process](#application-process)
 * [Recognition of Prior Learning (RPL) Application](#recognition-of-prior-learning-rpl-application)
-* [Frequently Asked Questions (FAQs)](#faqs)
+* [Frequently Asked Questions (FAQs)](#frequently-asked-questions-faqs)
 * [Additional Resources](#additional-resources)
+
+<!-- vim-markdown-toc -->
 
 ## Administrative Information: Admissions Process and Requirements
 Students may apply to the programme in two of the following ways:

--- a/online_courses/paid/README.md
+++ b/online_courses/paid/README.md
@@ -2,10 +2,12 @@
 
 # Paid online courses
 # Table of contents
-- [Paid online courses](#paid-online-courses)
-- [Table of contents](#table-of-contents)
-- [Subscription-based](#subscription-based)
-- [Pay per course](#pay-per-course)
+<!-- vim-markdown-toc GFM -->
+
+* [Subscription-based](#subscription-based)
+* [Pay per course](#pay-per-course)
+
+<!-- vim-markdown-toc -->
 
 ---
 


### PR DESCRIPTION
- This helps with consistency since the table of contents is
automatically updated every time the file is saved when the Vim plugin
is installed. Anytime a heading may be modified, it will be picked up.
- This is especially useful when two or more items have the same
sub-heading, since those need to be numbered for the links to work
properly. This is something that also happens automatically with that
plugin, which helps to avoid broken links that won't be verified with
the current link checker script.
- Sure, other plugins work too, but I bet I'll be the main contributor
for a while so I'm just trying to make my own life a bit easier ;).