### PR TITLE
Added new subreddit-article about progression requirements within degree

### DIFF
--- a/subreddit/README.md
+++ b/subreddit/README.md
@@ -23,6 +23,7 @@ Note: this index is copied from `./resources-links/links-reddit-sticky.md`, with
 - [**Everything You Want to Know about the Institutional Accreditation of the University of London et al**](accreditation.md): A VERY detailed and source-heavy document with many links, detailing the accreditation of the course programme.
 - [**Applying for a Recognition of Prior Learning: Or How to Save £400 to £600 GBP**](rpl-guide.md): A student post which explains what RPLs are, and walks you through the process of getting a RPL via Coursera's Google IT Cert.
 - [**Interview with David C.**](interview-david-c.md) An interview with a student on their experiences in the programme
+- [**Guide to Module Prerequisites & Progression: How to Avoid Being 'Progression-Blocked' due to Missing Prerequisites, and a Suggested Module Schedule**](progression.md): An explanation of the University of London's progression rules and prerequisites, as well as a suggested schedule for new students.
 
 ## About resources-links
 

--- a/subreddit/progression.md
+++ b/subreddit/progression.md
@@ -1,0 +1,127 @@
+# Guide to Module Prerequisites & Progression: How to Avoid Being 'Progression-Blocked' due to Missing Prerequisites, and a Suggested Module Schedule
+Hello there, /r/UniversityofLondonCS!
+
+We've recently had posts and comments with questions regarding the progression within this degree programme, especially from new applicants. I decided to write this post as a general guide to progression within the programme, explain the prerequisites for advancement from FHEQ Level 4 to Level 5, as well as present a suggested module schedule.
+
+## How does progression work within this degree programme?
+The University of London's Bachelor's of Science in Computer Science is composed of [22 modules plus a Final Project](https://london.ac.uk/computer-science-structure) (For more information regarding the degree's structure, [see my other guide](grades-guide.md)). These 22 modules are all worth 15 credits each, and are divided into three levels: There are FHEQ Level 4 modules, FHEQ Level 5 modules, and FHEQ Level 6 modules.
+
+Each Level is more advanced than the previous Level, hence there are *progression rules* which govern when a student may register for Level 5 and Level 6 modules. As this guide is intended for applicants and new students, we will only discuss the progression requirements of Level 5 modules:
+
+> **Requirements to progress through the BSc**
+>
+> **5.6**
+>
+> To progress to FHEQ Level 5 modules, you must have:
+>
+> * Passed, or been awarded credit through recognition of prior learning, for at least 45 credits at Level 4, including Introduction to Programming I and either Discrete or Computational Mathematics; and
+>
+> * made an attempt at a further 45 credits at Level 4, including both Introduction to Programming II and the remaining Level 4 maths module; and
+>
+> * registered for any Level 4 modules not yet attempted alongside your Level 5 modules, excluding any for which you have been awarded credit through recognition of prior learning
+
+Source: [Programme Regulations, Section 5.6, Page 12](https://london.ac.uk/sites/default/files/regulations/progregs-computer-science-2020-21.pdf)
+
+## Are all Level 4 modules offered every term?
+**No. The Discrete Mathematics (DM) and Computational Mathematics (CM) modules are only available on an alternating basis.** Discrete Mathematics is only available on the October (Fall) term, while Computational Mathematics is only available on the April (Spring) term.
+
+Other than this exception, all other level 4 modules are available every term.
+
+## What does it mean to become 'progression-blocked?'
+Because the DM and CM modules are only available on an alternating basis, if you do not register (and complete) them one after the other, you could end up in a situation where you are blocked from progressing on to Level 5 modules due to not fulfilling the progression requirements. Here's an example of a student that became 'progression-blocked':
+
+**1st Term (Only DM is offered)**
+
+Normal progression:
+
+* Intro to Prog I
+* **Discrete Maths**
+* Web Development
+
+**2nd Term (Only CM is offered)**
+
+Normal progression:
+
+* Intro to Prog II
+* How Computers Work
+* Algorithms and Datastructures
+
+**3rd Term (Only DM is offered)**
+
+**Progression Blocked!**
+Cannot register for any Level 5 modules because CM is not completed. Cannot register for CM because only DM is offered this term!
+
+
+* Fundamentals of CS
+
+**4th Term (Only CM is offered)**
+
+**Progression Blocked!**
+Cannot register for any Level 5 modules because CM is not completed!
+
+* **Computational Maths**
+
+As you can see in the above example, the student who became 'progression-blocked' is forced to spend their 3rd and 4th term enrolling in only 1 module, instead of 3. Only by their 5th term will they be able to enroll in all Level 5 modules as normal. This obviously delays one's expected graduation date, and it is best avoided.
+
+## How can I not become 'progression-blocked?'
+**The simplest way to not run afoul of progression requirements is to take your maths (and programming) modules one after the other.** This means if you have CM offered in your first term, register for DM in your second term, and vice versa.
+
+Essentially, the *gatekeeping* modules in Level 4 are your maths (CM/DM) and programming (Intro to Prog I, Intro to Prog II) modules, as they are the only ones specifically listed in the progression section of the programme regulations. As long as you make sure to take your maths and programming modules one right after the other, you may register for your remaining Level 4 modules in whatever order you wish, without fear of becoming 'progression-blocked'
+
+## What is your recommended 'schedule' of modules to take which will avoid 'progression-blocking'?
+
+You really don't need a schedule to not be progression-blocked, as long as you complete your maths and programming modules right after each other. However for those who are worried, the following schedules will guarantee progression from Level 4 to Level 5.
+
+### Recommended schedule for 3 modules per term
+**1st Term**
+
+* **Intro to Prog I**
+* **CM/DM (whichever is offered)**
+* *[Any Level 4 module]*
+
+**2nd Term**
+
+* **Intro to Prog II**
+* **CM/DM (whichever is offered)**
+* *[Any Level 4 module]*
+
+**3rd Term**
+
+* *[No longer at risk of being 'progression-blocked']*
+
+### Recommended schedule for 4 modules per term
+**1st Term**
+
+* **Intro to Prog I**
+* **CM/DM (whichever is offered)**
+* *[Any Level 4 module]*
+* *[Any Level 4 module]*
+
+**2nd Term**
+
+* **Intro to Prog II**
+* **CM/DM (whichever is offered)**
+* *[Any Level 4 module]*
+* *[Any Level 4 module]*
+
+### 3rd Term
+* *[No longer at risk of being 'progression-blocked']*
+
+## What about progression from Level 5 to Level 6? Or from Level 6 to Final Project?
+There is are separate sets of progression requirements which govern further progression into the degree programme. These rules can be found in the [Programme Regulations, Sections 5.6 and 5.8 (pages 12-13)](https://london.ac.uk/sites/default/files/regulations/progregs-computer-science-2020-21.pdf).
+
+As these are more advanced topics that are only relevant to advanced students, they are out-of-scope for this guide. Students are encouraged to consult the Programme Regulations, and direct their questions to the private students-only Slack.
+
+## What happens if I am unable to take CM/DM right after each other, as suggested?
+You may run into issues. You could potentially avoid being severely delayed [if you plan things out carefully](https://www.reddit.com/r/UniversityOfLondonCS/comments/koeeo8/how_not_to_fall_in_pba/ghup7un/)... but in general, it is *highly* inadvisable.
+
+## Conclusion and Further Resources
+
+- [General Regulations](https://london.ac.uk/sites/default/files/regulations/progregs-general-2020-2021.pdf)
+- [Programme Regulations](https://london.ac.uk/sites/default/files/regulations/progregs-computer-science-2020-21.pdf)
+- [Programme Specification](https://london.ac.uk/sites/default/files/programme-specifications/progspec-computer-science-2020-21.pdf)
+- [Computer Science - Structure](https://london.ac.uk/computer-science-structure)
+
+Thank you all for reading this guide to progression requirements within the University of London's BSc of Computer Science! If you have any questions, feel free to join us at the unofficial Discord server ([invitation link](https://discord.gg/GhRFG5X))!
+
+Likewise, be sure to check out the resources available to you in the [FAQ page](README.md)!

--- a/subreddit/resources-links/links-discord-resources.md
+++ b/subreddit/resources-links/links-discord-resources.md
@@ -1,4 +1,4 @@
-:flag_gb: **Information on UoL's BSc Computer Science** :flag_gb:
+:gb: **Information on UoL's BSc Computer Science** :gb:
 Collection of links :link: and PDFs :page_facing_up: about the University of London's Bachelor's of Science in Computer Science degree programme.
 
 **BSc Computer Science Programme Homepage**
@@ -25,7 +25,7 @@ The 'Bible' of the BSc Computer Science degree. _If you will only read one docum
 A broad outline and overview of the structure and content of the degree, entry level qualifications, and learning outcomes.
 :page_facing_up: https://london.ac.uk/sites/default/files/programme-specifications/progspec-computer-science-2020-21.pdf
 
-:flag_gb: **About the University of London** :flag_gb:
+:gb: **About the University of London** :gb:
 Links :link: and PDFs :page_facing_up: about the University of London in general, as well as resources for students.
 
 **University of London Website**
@@ -58,7 +58,7 @@ Important legal contract which covers the consumer rights and legal protections 
 Tuition for the University of London is dependant on your 'Country Band'. _As of August 2020, Band A countries pay £420 GBP per module, while Band B countries pay £630 GBP per module._
 :page_facing_up: https://london.ac.uk/sites/default/files/leaflets/country-bands.pdf
 
-:flag_gb: **Recognition of Prior Learning** :flag_gb:
+:gb: **Recognition of Prior Learning** :gb:
 **About Recognitions of Prior Learning**
 General information on Recognition of Prior learning at the University of London
 :link: https://london.ac.uk/applications/how-apply/recognition-prior-learning
@@ -148,3 +148,4 @@ An explanation of the University of London's progression rules and prerequisites
 Although we are primarily for students and prospies in the University of London's Computer Science programme, there are also students from other UoL distance-learning programmes as well. All are welcome in this environment!
 
 :globe_with_meridians: **https://www.reddit.com/r/UniversityOfLondonCS/** :globe_with_meridians:
+

--- a/subreddit/resources-links/links-discord-resources.md
+++ b/subreddit/resources-links/links-discord-resources.md
@@ -140,6 +140,10 @@ A VERY detailed and source-heavy document with many links, detailing the accredi
 A student post which explains what RPLs are, and walks you through the process of getting a RPL via Coursera's Google IT Cert.
 :link: https://www.reddit.com/r/UniversityOfLondonCS/comments/hhjr2r/applying_for_a_recognition_of_prior_learning_rpl/
 
+**Guide to Module Prerequisites & Progression: How to Avoid Being 'Progression-Blocked' due to Missing Prerequisites, and a Suggested Module Schedule**
+An explanation of the University of London's progression rules and prerequisites, as well as a suggested schedule for new students.
+:link: https://www.reddit.com/r/UniversityOfLondonCS/comments/kp5mb0/guide_to_module_prerequisites_progression_how_to/
+
 **Be sure to check out /r/UniversityOfLondonCS - the Official Unofficial student subreddit of this programme**
 Although we are primarily for students and prospies in the University of London's Computer Science programme, there are also students from other UoL distance-learning programmes as well. All are welcome in this environment!
 

--- a/subreddit/resources-links/links-reddit-sticky.md
+++ b/subreddit/resources-links/links-reddit-sticky.md
@@ -1,6 +1,6 @@
 # Links, Resources, and FAQs for the University of London Bachelor's of Science in Computer Science Programme
 
-**Updated as of 2020-08-04 (August 4th, 2020)**
+**Updated as of 2021-01-02 (January 2rd, 2021)**
 
 Hello /r/UniversityOfLondonCS,
 
@@ -16,109 +16,99 @@ This post is divided into four general sections:
 ---
 
 ## Information on UoL's BSc Computer Science 🇬🇧
-
 Collection of links 🔗 and PDFs 📄 about the University of London's Bachelor's of Science in Computer Science degree programme.
 
 ### [**BSc Computer Science Programme Homepage**](https://london.ac.uk/courses/computer-science)
-
 University of London's main programme homepage for the BSc Computer Science. Contains more information than the Coursera webpage.
 
 ### [**BSc Computer Science Coursera Webpage**](https://www.coursera.org/degrees/bachelor-of-science-computer-science-london/)
-
 Coursera's webpage for the University of London's BSc Computer Science programme. Contains links to the application portal.
 
 ### [**BSc Computer Science Prospectus (2020)**](https://london.ac.uk/sites/default/files/prospectuses/computer-science-prospectus-2020.pdf)
-
 Admissions prospectus on the BSc Computer Science for interested students. A polished, informative summary of the Programme.
 
 ### [**Structure & Module Descriptions**](https://london.ac.uk/computer-science-structure)
-
 A high-level summary of the 22 modules and Final Project which makes up the Programme, seperated by Levels.
 
 ### [**Programme Regulations (2020-2021)**](https://london.ac.uk/sites/default/files/regulations/progregs-computer-science-2020-21.pdf)
+The 'Bible' of the BSc Computer Science degree. *If you will only read one document from this section, read this one.* Contains almost every detail about specific workings and regulations.
 
-The 'Bible' of the BSc Computer Science degree. _If you will only read one document from this section, read this one._ Contains almost every detail about specific workings and regulations.
 
 ### [**Programme Specification (2020-2021)**](https://london.ac.uk/sites/default/files/programme-specifications/progspec-computer-science-2020-21.pdf)
-
 A broad outline and overview of the structure and content of the degree, entry level qualifications, and learning outcomes.
 
 ---
 
 ## About the University of London 🇬🇧
-
 Links 🔗 and PDFs 📄 about the University of London in general, as well as resources for students.
 
-- [**University of London Website**](https://london.ac.uk/) The official website of the University of London. Did you know that the University of London has been offering Distance-Learning programmes since the 19th century?
-- [**University of London Prospectus (2020)**](https://london.ac.uk/sites/default/files/prospectuses/GIP-2020.pdf) Admissions prospectus about the University of London in general. A polished, informative summary for the prospective student.
-- [**General Regulations**](https://london.ac.uk/sites/default/files/regulations/progregs-general-2020-2021.pdf) Handbook of rules and regulations governing the University of London _If you will only read one document from this section, read this one._ Contains almost every detail about specific workings and systems of the University of London.
-- [**Student's Guide**](https://my.london.ac.uk/documents/10197/2676152/Student+Guide/07f72f0b-fd7d-cc23-603f-db6c31bfa5e2) Guide for current students of the University of London. Includes information like how to get funding, online libraries, and support networks
-- [**Student Terms and Conditions**](https://london.ac.uk/sites/default/files/governance/student-terms-and-conditions.pdf) Important legal contract which covers the consumer rights and legal protections for enrolled students. Includes information on refunds.
-- [**List of Exam Centres (Worldwide)**](https://my.london.ac.uk/documents/10197/2926462/examcentres-worldwide2/659d044f-25c3-2a01-fd7e-0667e3d9e71a)
-- [**List of Exam Centres (USA and Canada)**](https://my.london.ac.uk/documents/10197/2926462/examcentres-northamerica.pdf/da80d4a8-00db-053c-283a-0757f88b5e85)
-- [**Table of Country Bands (for Tuition)**](https://london.ac.uk/sites/default/files/leaflets/country-bands.pdf) Tuition for the University of London is dependant on your 'Country Band'. _As of August 2020, Band A countries pay £420 GBP per module, while Band B countries pay £630 GBP per module._
+* [**University of London Website**](https://london.ac.uk/) The official website of the University of London. Did you know that the University of London has been offering Distance-Learning programmes since the 19th century?
+* [**University of London Prospectus (2020)**](https://london.ac.uk/sites/default/files/prospectuses/GIP-2020.pdf) Admissions prospectus about the University of London in general. A polished, informative summary for the prospective student.
+* [**General Regulations**](https://london.ac.uk/sites/default/files/regulations/progregs-general-2020-2021.pdf) Handbook of rules and regulations governing the University of London *If you will only read one document from this section, read this one.* Contains almost every detail about specific workings and systems of the University of London.
+* [**Student's Guide**](https://my.london.ac.uk/documents/10197/2676152/Student+Guide/07f72f0b-fd7d-cc23-603f-db6c31bfa5e2) Guide for current students of the University of London. Includes information like how to get funding, online libraries, and support networks
+* [**Student Terms and Conditions**](https://london.ac.uk/sites/default/files/governance/student-terms-and-conditions.pdf) Important legal contract which covers the consumer rights and legal protections for enrolled students. Includes information on refunds.
+* [**List of Exam Centres (Worldwide)**](https://my.london.ac.uk/documents/10197/2926462/examcentres-worldwide2/659d044f-25c3-2a01-fd7e-0667e3d9e71a)
+* [**List of Exam Centres (USA and Canada)**](https://my.london.ac.uk/documents/10197/2926462/examcentres-northamerica.pdf/da80d4a8-00db-053c-283a-0757f88b5e85)
+* [**Table of Country Bands (for Tuition)**](https://london.ac.uk/sites/default/files/leaflets/country-bands.pdf) Tuition for the University of London is dependant on your 'Country Band'. *As of August 2020, Band A countries pay £420 GBP per module, while Band B countries pay £630 GBP per module.*
 
 ---
 
 ## University of London Váradi Scholarships
-
-- [**Fully paid scholarships available to all new students**](https://london.ac.uk/applications/funding-your-study/scholarships-and-bursaries/varadi-scholarships)
+* [**Fully paid scholarships available to all new students**](https://london.ac.uk/applications/funding-your-study/scholarships-and-bursaries/varadi-scholarships)
 
 ## Recognition of Prior Learning
+* [**About Recognitions of Prior Learning**](https://london.ac.uk/applications/how-apply/recognition-prior-learning) General information on Recognition of Prior learning at the University of London
+* [**Applying for RPLs & Automatic RPLs**](https://london.ac.uk/applications/how-apply/recognition-prior-learning/recognition-and-accreditation-prior-learning-3) Specific information on applying for a RPL for the BSc Computer Science programme, and list of Automatic RPLs
+* [**Coursera Google IT Cert**](https://www.coursera.org/professional-certificates/google-it-support) Yes, this is the correct one. Complete this in order to apply for an RPL to bypass the How Computer's Work module.
+* [**Applying for a Recognition of Prior Learning: Or How to Save £400 to £600 GBP**](https://www.reddit.com/r/UniversityOfLondonCS/comments/hhjr2r/applying_for_a_recognition_of_prior_learning_rpl/): A student post which explains what RPLs are, and walks you through the process of getting a RPL via Coursera's Google IT Cert.
 
-- [**About Recognitions of Prior Learning**](https://london.ac.uk/applications/how-apply/recognition-prior-learning) General information on Recognition of Prior learning at the University of London
-- [**Applying for RPLs & Automatic RPLs**](https://london.ac.uk/applications/how-apply/recognition-prior-learning/recognition-and-accreditation-prior-learning-3) Specific information on applying for a RPL for the BSc Computer Science programme, and list of Automatic RPLs
-- [**Coursera Google IT Cert**](https://www.coursera.org/professional-certificates/google-it-support) Yes, this is the correct one. Complete this in order to apply for an RPL to bypass the How Computer's Work module.
-- [**Applying for a Recognition of Prior Learning: Or How to Save £400 to £600 GBP**](https://www.reddit.com/r/UniversityOfLondonCS/comments/hhjr2r/applying_for_a_recognition_of_prior_learning_rpl/): A student post which explains what RPLs are, and walks you through the process of getting a RPL via Coursera's Google IT Cert.
 
 ## Student-Run Resources and Community
-
 Links to various student-made resources and community portal
 
-- [**Resources Enriching Learners Perennially (Student Hub)**](https://world-class.github.io/REPL/): This is the main student-run community hub. Contains many informative resources and guides. _If you will only read one document from this section, read this one._
-- [**Student & Professor Notes Github Repository**](https://github.com/world-class/REPL/tree/master/notes): Collection of notes contributed by students and professors.
-- [**Student Module Guides**](https://github.com/world-class/REPL/tree/master/modules/level_4): Various FAQs and guides to the different modules. Contains many informative links and module-specific documents
-- [**Slack Channel Guide**](https://world-class.github.io/REPL/slack/): An overview of the vibrant Slack community, and the various channels that are available.
+* [**Resources Enriching Learners Perennially (Student Hub)**](https://world-class.github.io/REPL/): This is the main student-run community hub. Contains many informative resources and guides. *If you will only read one document from this section, read this one.*
+* [**Student & Professor Notes Github Repository**](https://github.com/world-class/REPL/tree/master/notes): Collection of notes contributed by students and professors.
+* [**Student Module Guides**](https://github.com/world-class/REPL/tree/master/modules/level_4): Various FAQs and guides to the different modules. Contains many informative links and module-specific documents
+* [**Slack Channel Guide**](https://world-class.github.io/REPL/slack/): An overview of the vibrant Slack community, and the various channels that are available.
 
 ## Useful posts from /r/UniversityOfLondonCS
-
 Here is a collection of useful, in-depth guides, tutorials, and walkthroughs published by [/u/Yangchenghu](https://www.reddit.com/user/Yangchenghu) from the [/r/UniversityOfLondonCS](https://www.reddit.com/r/UniversityOfLondonCS/) subreddit.
 
-- [**Beginner's Guide to Grades, Projects, Exams, and Award Qualifications at UoL's CompSci BSc**](https://www.reddit.com/r/UniversityOfLondonCS/comments/hgbcc8/beginners_guide_to_grades_projects_exams_and/): A good overview of how the academic structure of the degree works, plus examples of past mid-terms and exam papers.
-- [**Thoughts on UoL's BSc in Computer Science - A Comprehensive Review**](https://www.reddit.com/r/UniversityOfLondonCS/comments/hf8cwy/thoughts_on_university_of_londons_bachelors_in/): In-depth review of /u/Yangchenghu's experiences as a first cohort student, with screenshots of the Virtual Learning Environment and Slack.
-- [**Let's Talk About The Balance of Formative Coursework versus Summative Assessments**](https://www.reddit.com/r/UniversityOfLondonCS/comments/hgx9zs/lets_talk_about_the_balance_of_formative/): Explains how grades and optional assignments work, which segues into a more philosophical discussion on self-driven learning.
-- [**Legal Protections for the Distance-Learning Student: The Rights and Protections you are Entitled To**](https://www.reddit.com/r/UniversityOfLondonCS/comments/hldddc/legal_protections_for_the_distancelearning/): Gives a overview of the Student Terms and Conditions document, and outlines the rights to refund and withdrawl.
-- [**Everything You Want to Know about the Institutional Accreditation of the University of London et al**](https://www.reddit.com/r/UniversityOfLondonCS/comments/hzumke/everything_you_want_to_know_about_the/): A VERY detailed and source-heavy document with many links, detailing the accreditation of the course programme.
-- [**Applying for a Recognition of Prior Learning: Or How to Save £400 to £600 GBP**](https://www.reddit.com/r/UniversityOfLondonCS/comments/hhjr2r/applying_for_a_recognition_of_prior_learning_rpl/): A student post which explains what RPLs are, and walks you through the process of getting a RPL via Coursera's Google IT Cert.
+* [**Beginner's Guide to Grades, Projects, Exams, and Award Qualifications at UoL's CompSci BSc**](https://www.reddit.com/r/UniversityOfLondonCS/comments/hgbcc8/beginners_guide_to_grades_projects_exams_and/): A good overview of how the academic structure of the degree works, plus examples of past mid-terms and exam papers.
+* [**Thoughts on UoL's BSc in Computer Science - A Comprehensive Review**](https://www.reddit.com/r/UniversityOfLondonCS/comments/hf8cwy/thoughts_on_university_of_londons_bachelors_in/): In-depth review of /u/Yangchenghu's experiences as a first cohort student, with screenshots of the Virtual Learning Environment and Slack.
+* [**Let's Talk About The Balance of Formative Coursework versus Summative Assessments**](https://www.reddit.com/r/UniversityOfLondonCS/comments/hgx9zs/lets_talk_about_the_balance_of_formative/): Explains how grades and optional assignments work, which segues into a more philosophical discussion on self-driven learning.
+* [**Legal Protections for the Distance-Learning Student: The Rights and Protections you are Entitled To**](https://www.reddit.com/r/UniversityOfLondonCS/comments/hldddc/legal_protections_for_the_distancelearning/): Gives a overview of the Student Terms and Conditions document, and outlines the rights to refund and withdrawl.
+* [**Everything You Want to Know about the Institutional Accreditation of the University of London et al**](https://www.reddit.com/r/UniversityOfLondonCS/comments/hzumke/everything_you_want_to_know_about_the/): A VERY detailed and source-heavy document with many links, detailing the accreditation of the course programme.
+* [**Applying for a Recognition of Prior Learning: Or How to Save £400 to £600 GBP**](https://www.reddit.com/r/UniversityOfLondonCS/comments/hhjr2r/applying_for_a_recognition_of_prior_learning_rpl/): A student post which explains what RPLs are, and walks you through the process of getting a RPL via Coursera's Google IT Cert.
+* [**Guide to Module Prerequisites & Progression: How to Avoid Being 'Progression-Blocked' due to Missing Prerequisites, and a Suggested Module Schedule**](https://www.reddit.com/r/UniversityOfLondonCS/comments/kp5mb0/guide_to_module_prerequisites_progression_how_to/): An explanation of the University of London's progression rules and prerequisites, as well as a suggested schedule for new students.
 
-[**Be sure to check out /r/UniversityOfLondonCS - the Official Unofficial student subreddit of this programme**](https://www.reddit.com/r/UniversityOfLondonCS). Although we are primarily for students and prospies in the University of London's Computer Science programme, there are also students from other UoL distance-learning programmes as well. All are welcome in this environment!
+
+[**Be sure to check out /r/UniversityOfLondonCS - the Official Unofficial student subreddit of this programme**](https://www.reddit.com/r/UniversityOfLondonCS/). Although we are primarily for students and prospies in the University of London's Computer Science programme, there are also students from other UoL distance-learning programmes as well. All are welcome in this environment!
 
 ## Login Portals for Currently Enrolled Students
-
 Links to various login portals for currently enrolled students. Valid account credentials at the University of London is required for access.
 
-- [**University of London Student Portal**](https://my.london.ac.uk/)
-- [**Virtual Learning Environment (Coursera)**](https://www.coursera.org/?authMode=login&authProvider=london)
-- [**Student Slack Workspace**](https://londoncs.slack.com/)
-- [**University of London Student Email**](http://mail.google.com/a/student.london.ac.uk)
-- [**Online Library and Databases**](http://onlinelibrary.london.ac.uk/)
+* [**University of London Student Portal**](https://my.london.ac.uk/)
+* [**Virtual Learning Environment (Coursera)**](https://www.coursera.org/?authMode=login&authProvider=london)
+* [**Student Slack Workspace**](https://londoncs.slack.com/)
+* [**University of London Student Email**](http://mail.google.com/a/student.london.ac.uk)
+* [**Online Library and Databases**](http://onlinelibrary.london.ac.uk/)
 
 ## Related Posts from the University of London Blog
-
 Misc. blog posts and other fluff from the University of London Blog that showcases various aspects of the degree.
 
-- [**Project-Based Learning in BSc Computer Science**](https://london.ac.uk/news-opinion/london-connection/feature/build-a-digital-portfolio-your-future-career)
+* [**Project-Based Learning in BSc Computer Science**](https://london.ac.uk/news-opinion/london-connection/feature/build-a-digital-portfolio-your-future-career)
 
-- [**BSc Computer Science Gaming Specialisation**](https://london.ac.uk/news-opinion/london-connection/feature/ready-player-one-get-set-exciting-career-gaming)
+* [**BSc Computer Science Gaming Specialisation**](https://london.ac.uk/news-opinion/london-connection/feature/ready-player-one-get-set-exciting-career-gaming)
 
-- [**Studying Two Degrees at Once**](https://london.ac.uk/news-and-opinion/student-blog/combining-two-degrees-a-story-plato-and-programming)
+* [**Studying Two Degrees at Once**](https://london.ac.uk/news-and-opinion/student-blog/combining-two-degrees-a-story-plato-and-programming)
 
 ---
 
 ## Frequently Asked Questions (FAQs)
 
-There is a _comprehensive, fantastically detailed_ FAQ located at the REPL Hub. The link to it is right here:
+There is a *comprehensive, fantastically detailed* FAQ located at the REPL Hub. The link to it is right here:
 
-- [**Frequently Asked Questions (REPL Hub)**](https://world-class.github.io/REPL/faq/)
+* [**Frequently Asked Questions (REPL Hub)**](https://world-class.github.io/REPL/faq/)
 
 Remember, REPL is the centre of all the student-run resources, make sure to check it out! It has student-written guides for the various modules, as well as notes and links. If you think this reddit post is too long, just wait until you see REPL - it's even better! :D


### PR DESCRIPTION
Adding a new subreddit article from /u/Yangchenghu on the /r/UniversityOfLondonCS subreddit to the REPL Hub. The article is a Guide on Module Prerequisites & Progression Requirements, and it is already live at the following Reddit URL:


https://www.reddit.com/r/UniversityOfLondonCS/comments/kp5mb0/guide_to_module_prerequisites_progression_how_to/

For inclusion within the REPL repository, all links in the article have been canonicalised, so they lead directly to their respective markdown files within the repository, and do not take the reader to reddit.

Likewise, the various FAQs and resource-links have been updated to include the new article.