### PR TITLE
Level 5 SDD and CS modules: add links in Readme to mock exams in binary-assets repo

### DIFF
--- a/modules/level_5/cm_2010_software_design_and_development/README.md
+++ b/modules/level_5/cm_2010_software_design_and_development/README.md
@@ -45,6 +45,10 @@ software versioning tools to manage a software project as it develops.
 
 One two hour unseen written examination and coursework (Type I)
 
+# Mock exam
+
+[See the `binary-assets` repository](https://github.com/world-class/binary-assets/tree/master/modules/cm2010_sdd).
+
 # Module specification
 
 - [Module specification (September 2020)](https://github.com/world-class/binary-assets/blob/master/modules/module_specification/CM2010_SDD-Module-Spec.pdf)

--- a/modules/level_5/cm_2010_software_design_and_development/README.md
+++ b/modules/level_5/cm_2010_software_design_and_development/README.md
@@ -47,7 +47,7 @@ One two hour unseen written examination and coursework (Type I)
 
 # Mock exam
 
-[See the `binary-assets` repository](https://github.com/world-class/binary-assets/tree/master/modules/cm2010_sdd).
+[March 2021 mock exam](https://github.com/world-class/binary-assets/blob/master/modules/cm2010_sdd/cm2010_SDD_mock_exam.pdf).
 
 # Module specification
 

--- a/modules/level_5/cm_2015_programming_with_data/README.md
+++ b/modules/level_5/cm_2015_programming_with_data/README.md
@@ -72,6 +72,8 @@ One two hour unseen written examination and coursework (Type I)
 ### Data Science
 
 - [Foundations of Data Science: K-Means Clustering in Python](https://www.coursera.org/learn/data-science-k-means-clustering-python) - Coursera, by Dr Matthew Yee-King +3 more instructors.
+- [Data Science playlist](https://www.youtube.com/watch?v=GjKQ6V_ViQE&list=PLFCB5Dp81iNVmuoGIqcT5oF4K-7kTI5vp) - Youtube, by Keith Galli: web scraping, numpy, pandas, plotting, NLP, sklearn.
+- [Machine Learning & Data Science playlist](https://www.youtube.com/watch?v=sEte4hXEgJ8&list=PLGLfVvz_LVvQy4mkmEvtFwZGg1S38MUmn) - Youtube, by Derek Banas: probability, statistics, numpy, pandas, plotting, time series
 
 ### Python
 

--- a/modules/level_5/cm_2025_computer_security/README.md
+++ b/modules/level_5/cm_2025_computer_security/README.md
@@ -41,7 +41,7 @@ One two hour unseen written examination and coursework (Type I)
 
 # Mock exam
 
-[See the `binary-assets` repository](https://github.com/world-class/binary-assets/tree/master/modules/cm2025_cs).
+[March 2021 mock exam](https://github.com/world-class/binary-assets/blob/master/modules/cm2025_cs/cm2025_CS_mock_exam.pdf).
 
 # Module specification
 

--- a/modules/level_5/cm_2025_computer_security/README.md
+++ b/modules/level_5/cm_2025_computer_security/README.md
@@ -39,6 +39,10 @@ mathematics underlying the protocols by programming small examples.
 
 One two hour unseen written examination and coursework (Type I)
 
+# Mock exam
+
+[See the `binary-assets` repository](https://github.com/world-class/binary-assets/tree/master/modules/cm2025_cs).
+
 # Module specification
 
 - [Module specification (September 2020)](https://github.com/world-class/binary-assets/blob/master/modules/module_specification/CM2025_CS-Module-Spec.pdf)


### PR DESCRIPTION
## Updating Documentation for Level 5 Modules SDD and CS

```
### Description of the Change
<!-- 
This PR adds links from level 5 SDD and CS Readme.md files 
to their mock exam files in the binary asset repository following binary-assets commits 
fddf26890ced646965518e42df05d84f1bbeb0e4 and 3a798872e5ea3de13173a1ea2f77444e7150e18b
-->

```