### PR TITLE
Add past exam papers and solutions for DM, ADS1, and FCS

### DIFF
--- a/modules/level_4/cm_1020_discrete_mathematics/README.md
+++ b/modules/level_4/cm_1020_discrete_mathematics/README.md
@@ -99,6 +99,7 @@ _This course does not require you to read the whole book, you will be given spec
 
 - 2014, 2015, 2016, 2017, 2018 ([PDF with answers](https://github.com/world-class/binary-assets/blob/master/modules/past_exams/cm1020_dm/DM18_answers.pdf)), 2020 ([PDF with answers](https://github.com/world-class/binary-assets/blob/master/modules/past_exams/cm1020_dm/DM20_answers.pdf)): [Visit this page](https://github.com/world-class/binary-assets/tree/master/modules/past_exams/cm1020_dm).
 - :lock: [2020 written exam] **enrolled students**: answers are being compiled on Slack, [see this thread](https://londoncs.slack.com/archives/CKZT2LKPW/p1582307389452400).
+- [DM March 2020 exam](https://github.com/world-class/binary-assets/blob/master/modules/past_exams/cm1020_dm/DM2020-03-03.pdf)
 
 ## Kinks to be aware of
 

--- a/modules/level_4/cm_1025_fundamentals_of_computer_science/README.md
+++ b/modules/level_4/cm_1025_fundamentals_of_computer_science/README.md
@@ -108,6 +108,7 @@ _"Specific essential readings for each week from the following list are included
 - [FCS past exam March 2020](https://github.com/world-class/binary-assets/blob/master/modules/cm1025_fcs/CM1025_Exam_Questions_March_2020.pdf)
   - [Solutions (by students)](https://docs.google.com/spreadsheets/d/1YTfRO7cipoxUuxuYfWQrXslwBeJJ9Mlj3T9K3CNYl0w/edit#gid=0)
 - [FCS past exam September 2020 (Part B)](https://github.com/world-class/binary-assets/blob/master/modules/cm1025_fcs/CM1025_Exam_Questions_Sept_2020.pdf)
+  - [Solutions (by students)](https://jamboard.google.com/d/1HfJiFXtCtdK02W62-imDlDqsH2oqv48C0LoO66HCdhE/edit)
 
 ## Study guide
 

--- a/modules/level_4/cm_1035_algorithms_and_data_structures_i/README.md
+++ b/modules/level_4/cm_1035_algorithms_and_data_structures_i/README.md
@@ -122,6 +122,8 @@ _There will also be discussion prompts asking you to do some independent researc
 
 - 2014, 2015, 2016, 2018, 2020: [Visit this page](https://github.com/world-class/binary-assets/tree/master/modules/past_exams/cm1035_ads1).
 - :lock: [2020 written exam] **enrolled students**: more answers were compiled on Slack, [see this thread](https://londoncs.slack.com/archives/CKZT2SR0U/p1582561904016800).
+- [ADS1 September 2020 online exam](https://github.com/world-class/binary-assets/blob/master/modules/past_exams/cm1035_ads1/ADS2020-09-21.pdf)
+  - [Solutions](https://github.com/world-class/binary-assets/blob/master/modules/past_exams/cm1035_ads1/ADS2020-09-21_answers.pdf)
 
 ## Kinks to be aware of
 


### PR DESCRIPTION
### Add past exam papers and solutions

#### Papers added:

1. DM March 2020 exam
2. ADS1 September 2020 online exam
3. Official solutions for ADS1 September 2020 online exam
4. Student solutions for FCS September 2020 online exam