### PR TITLE
Fix links to past exams

### DIFF
--- a/modules/level-4/cm-1020-discrete-mathematics/README.md
+++ b/modules/level-4/cm-1020-discrete-mathematics/README.md
@@ -97,7 +97,7 @@ _This course does not require you to read the whole book, you will be given spec
 
 ## Examples of past and current written exams
 
-- 2014, 2015, 2016, 2017, 2018 ([PDF with answers](https://github.com/world-class/binary-assets/blob/master/modules/past-exams/cm1020-dm/DM18_answers.pdf)), 2020 ([PDF with answers](https://github.com/world-class/binary-assets/blob/master/modules/past-exams/cm1020_dm/DM20_answers.pdf)): [Visit this page](https://github.com/world-class/binary-assets/tree/master/modules/past-exams/cm1020-dm).
+- 2014, 2015, 2016, 2017, 2018 ([PDF with answers](https://github.com/world-class/binary-assets/blob/master/modules/past-exams/cm1020-dm/DM18_answers.pdf)), 2020 ([PDF with answers](https://github.com/world-class/binary-assets/blob/master/modules/past-exams/cm1020-dm/DM20_answers.pdf)): [Visit this page](https://github.com/world-class/binary-assets/tree/master/modules/past-exams/cm1020-dm).
 - :lock: [2020 written exam] **enrolled students**: answers are being compiled on Slack, [see this thread](https://londoncs.slack.com/archives/CKZT2LKPW/p1582307389452400).
 - [DM March 2020 exam](https://github.com/world-class/binary-assets/blob/master/modules/past-exams/cm1020-dm/DM2020-03-03.pdf)
 

--- a/modules/level-4/cm-1035-algorithms-and-data-structures-i/README.md
+++ b/modules/level-4/cm-1035-algorithms-and-data-structures-i/README.md
@@ -120,7 +120,7 @@ _There will also be discussion prompts asking you to do some independent researc
 
 ## Examples of past and current written exams
 
-- 2014, 2015, 2016, 2018, 2020: [Visit this page](https://github.com/world-class/binary-assets/tree/master/modules/past-exams/cm1035_ads1).
+- 2014, 2015, 2016, 2018, 2020: [Visit this page](https://github.com/world-class/binary-assets/tree/master/modules/past-exams/cm1035-ads1).
 - :lock: [2020 written exam] **enrolled students**: more answers were compiled on Slack, [see this thread](https://londoncs.slack.com/archives/CKZT2SR0U/p1582561904016800).
 - [ADS1 September 2020 online exam](https://github.com/world-class/binary-assets/blob/master/modules/past-exams/cm1035-ads1/ADS2020-09-21.pdf)
   - [Solutions](https://github.com/world-class/binary-assets/blob/master/modules/past-exams/cm1035-ads1/ADS2020-09-21_answers.pdf)


### PR DESCRIPTION
### Fix links to past exams

Fix to the issue raised in [this](https://londoncs.slack.com/archives/CDTPC3FKL/p1621394482023700) thread. Changes underscore to hyphen for links to past exams at [ADS1](https://world-class.github.io/REPL/modules/level-4/cm-1035-algorithms-and-data-structures-i/) and [DM](https://world-class.github.io/REPL/modules/level-4/cm-1020-discrete-mathematics/) pages.