### PR TITLE
Fix internal links

### DIFF
--- a/modules/level-4/cm-1025-fundamentals-of-computer-science/README.md
+++ b/modules/level-4/cm-1025-fundamentals-of-computer-science/README.md
@@ -67,7 +67,7 @@ One two hour unseen written examination and coursework (Type I)
 - Highly recommended for week 7 onwards: [lectures](https://web.cs.ucdavis.edu/~rogaway/classes/120/spring14/) and [videos](https://www.cs.ucdavis.edu/~rogaway/classes/120/fall12/lectures.html) from Prof. Michael Harrison.
 - [Context-free grammar tool](https://web.stanford.edu/class/archive/cs/cs103/cs103.1156/tools/cfg/)
 - [Context-Free Grammar with Daniel Shiffman](https://shiffman.net/a2z/cfg/) - A fun way to understand CFG with real-world examples and programming.
-- [Easy Theory](https://www.youtube.com/c/EasyTheory/playlists) - _"This is a channel about making Computer Science theory as easy as possible."_ Relevant for this course as well as [Algorithms and Data Structures I](../algorithms_and_data_structures_i/README.md).
+- [Easy Theory](https://www.youtube.com/c/EasyTheory/playlists) - _"This is a channel about making Computer Science theory as easy as possible."_ Relevant for this course as well as [Algorithms and Data Structures I](../cm-1035-algorithms-and-data-structures-i/README.md).
 - [Great Ideas in Theoretical Computer Science](https://www.youtube.com/watch?v=khyrgbiz20o&list=PLm3J0oaFux3aafQm568blS9blxtA_EWQv) - Complementary topics, including proofs, deductive systems, logic, finite automata, Turing, time complexity, graph algorithms, etc.
 - [Guide to Negating Formulas](http://web.stanford.edu/class/archive/cs/cs103/cs103.1182/notes/Guide%20to%20Negating%20Formulas.pdf) (propositional logic) - stanford.edu
 - [Introduction to Theoretical Computer Science](https://introtcs.org/public/index.html)

--- a/modules/level-4/cm-1035-algorithms-and-data-structures-i/README.md
+++ b/modules/level-4/cm-1035-algorithms-and-data-structures-i/README.md
@@ -73,7 +73,7 @@ One two hour unseen written examination and coursework (Type I)
 
 - [Algorithmic Design and Techniques](https://courses.edx.org/courses/course-v1:UCSanDiegoX+ALGS200x+2T2017/course) - _edX platform, by UC San Diego_
 - [Data Structures Fundamentals](https://courses.edx.org/courses/course-v1:UCSanDiegoX+ALGS201x+1T2019/course) - _edX platform, by UC San Diego_
-- [Easy Theory](https://www.youtube.com/c/EasyTheory/playlists) - _"This is a channel about making Computer Science theory as easy as possible."_ Relevant for this course as well as [Fundamentals of Computer Science](../fundamentals_of_computer_science/README.md).
+- [Easy Theory](https://www.youtube.com/c/EasyTheory/playlists) - _"This is a channel about making Computer Science theory as easy as possible."_ Relevant for this course as well as [Fundamentals of Computer Science](../cm-1025-fundamentals-of-computer-science/README.md).
 
 ### Visualizations
 

--- a/slack/README.md
+++ b/slack/README.md
@@ -146,7 +146,7 @@ All channels starting with `#asg` for **Accountable Study Groups**.
 
 | Channel         | Specialism                                                                       |
 | --------------- | -------------------------------------------------------------------------------- |
-| `#data_science` | [Data Science](../modules/level-6/data_science/README.md)                        |
+| `#data_science` | [Data Science](../modules/level-6/data-science/README.md)                        |
 | `#gamedev`      | [Game Development](../modules/level-6/games-dev/README.md)                       |
 | `#iot`          | [Internet of Things](../modules/level-6/phys-computing-iot/README.md)            |
 | `#mlai`         | [Machine Learning & Artificial Intelligence](../modules/level-6/ml-ai/README.md) |


### PR DESCRIPTION
### Fix links

ADS1 and FCS mutual links now follow general scheme.

Data Science specialism link should point to correct page.