### PR TITLE
Update REPl with information from new regulations

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ following modules.</p>
 <td><a href="modules/level-6/cm-3030-games-development">Games Development</a></td>
 <td><strong>GD</strong></td>
 <td><strong>CM3030</strong></td>
-<td><strong>No</strong></td>
+<td>No</td>
 <td><code><a href="https://app.slack.com/client/TDT1N1BUG/C01JX9YQ32N">#cm3030-games-development</a></code></td>
 </tr>
 <tr>
@@ -383,7 +383,7 @@ following modules.</p>
 <td><a href="modules/level-6/cm-3025-virtual-reality">Virtual Reality</a></td>
 <td><strong>VR</strong></td>
 <td><strong>CM3025</strong></td>
-<td><strong>Yes</strong></td>
+<td>No</td>
 <td><code><a href="https://app.slack.com/client/TDT1N1BUG/C01KBKPQV3K">#cm3025-virtual-reality</a></code></td>
 </tr>
 </tbody>

--- a/faq/README.md
+++ b/faq/README.md
@@ -258,7 +258,7 @@ See https://github.com/yzhang-gh/vscode-markdown/issues/723#issuecomment-6423881
   2. you are still within your maximum period of registration;
   3. you have not failed at the final attempt, a module that is core on the degree to which you wish to transfer;
   4. you have not passed more than one Level 6 module which does not fit on the degree to which you wish to transfer;
-  5. you are not yet eligible for the BSc award upon which you are currently registered. For further information please see the [programme regulations](https://london.ac.uk/sites/default/files/regulations/progregs-computer-science-2020-21.pdf).
+  5. you are not yet eligible for the BSc award upon which you are currently registered. For further information please see the [programme regulations](https://london.ac.uk/sites/default/files/regulations/progregs-bsc-computer-science-2021-22.pdf).
 
 ### How can I drop/withdraw from module
 
@@ -267,7 +267,7 @@ See https://github.com/yzhang-gh/vscode-markdown/issues/723#issuecomment-6423881
 ### What is the maximum number of modules that one can select per semester and what if I fail one module
 
 - The maximum number of modules you can register for in any one session is five (or three plus the final project). This can be a combination of new modules and resits (with a maximum of four new modules), or resits only.
-- For further information please see the [programme regulations](https://london.ac.uk/sites/default/files/regulations/progregs-computer-science-2020-21.pdf).
+- For further information please see the [programme regulations](https://london.ac.uk/sites/default/files/regulations/progregs-bsc-computer-science-2021-22.pdf).
 
 ### Where can I see a syllabus or module specification of all available modules
 
@@ -353,7 +353,7 @@ See https://github.com/yzhang-gh/vscode-markdown/issues/723#issuecomment-6423881
 
 ## Programme regulations
 
-This (intentionally short!) section serves as a reminder to read [the programme regulations](https://london.ac.uk/sites/default/files/regulations/progregs-computer-science-2020-21.pdf) in details :book:, which answers general questions well enough.
+This (intentionally short!) section serves as a reminder to read [the programme regulations](https://london.ac.uk/sites/default/files/regulations/progregs-bsc-computer-science-2021-22.pdf) in details :book:, which answers general questions well enough.
 
 Some of the questions that can be answered by reading the programme regulations:
 

--- a/modules/level-6/cm-3025-virtual-reality/README.md
+++ b/modules/level-6/cm-3025-virtual-reality/README.md
@@ -30,7 +30,7 @@ building social VR experiences with interactive virtual characters.
 
 ### Assessment
 
-One two-hour unseen written examination and coursework (Type I)
+Coursework only (Type III)
 
 ## Resources
 

--- a/modules/level-6/cm-3030-games-development/README.md
+++ b/modules/level-6/cm-3030-games-development/README.md
@@ -43,7 +43,7 @@ of the relevant theory.
 
 ## Assessment
 
-Two unseen written examination and coursework (Type I) [midterm and final coursework]
+Coursework only (Type III)
 
 ## Module specification
 

--- a/subreddit/grades-guide.md
+++ b/subreddit/grades-guide.md
@@ -4,7 +4,7 @@ Hello /r/UniversityOfLondonCS!
 
 A lot of new prospective students have joined our Discord (if you haven't seen it yet, [check it out](https://discord.gg/GhRFG5X)!) -- and I've noticed a lot of questions regarding the grades and assessment structure of this degree.
 
-All of the information here is available in the [University of London General Regulations](https://london.ac.uk/sites/default/files/regulations/progregs-general-2020-2021.pdf), as well as the [degree-specific Programme Regulations](https://london.ac.uk/sites/default/files/regulations/progregs-computer-science-2020-21.pdf) -- but the documents are long and can be a bit obscure. Hence, I've decided to write a casual beginner's guide to how grades in this degree work.
+All of the information here is available in the [University of London General Regulations](https://london.ac.uk/sites/default/files/regulations/general-regulations-2021-2022.pdf), as well as the [degree-specific Programme Regulations](https://london.ac.uk/sites/default/files/regulations/progregs-bsc-computer-science-2021-22.pdf) -- but the documents are long and can be a bit obscure. Hence, I've decided to write a casual beginner's guide to how grades in this degree work.
 
 **This guide will take the form of an inverse-pyramid: I'll start by talking about the general organization of the degree as a whole, and then the grading and assessments of a typical module, and then finally the structure of a typical exam.**
 
@@ -40,7 +40,7 @@ These additional qualifications are called Intermediate Qualifications or Exit Q
 
 ## Structure of Assessments within a module
 
-Now that I've given a sufficient overview of the degree programme as a whole, go into further detail about grades and assessments in the typical class. Information for this section primarily comes from the [Programme Specification](https://london.ac.uk/sites/default/files/programme-specifications/progspec-computer-science-2020-21.pdf).
+Now that I've given a sufficient overview of the degree programme as a whole, go into further detail about grades and assessments in the typical class. Information for this section primarily comes from the [Programme Specification](https://london.ac.uk/sites/default/files/programme-specifications/progspec-bsc-computer-science.pdf).
 
 Typically, there are two general types of modules. I'll call them _"exam-based modules"_, or _"project-based modules"_ -- even though those aren't their real names.
 
@@ -111,7 +111,7 @@ As of always, if you have any further questions, you are welcome to ask me -- or
 
 ## Sources and Further Reading
 
-- [General Regulations](https://london.ac.uk/sites/default/files/regulations/progregs-general-2020-2021.pdf)
-- [Programme Regulations](https://london.ac.uk/sites/default/files/regulations/progregs-computer-science-2020-21.pdf)
-- [Programme Specification](https://london.ac.uk/sites/default/files/programme-specifications/progspec-computer-science-2020-21.pdf)
+- [General Regulations](https://london.ac.uk/sites/default/files/regulations/general-regulations-2021-2022.pdf)
+- [Programme Regulations](https://london.ac.uk/sites/default/files/regulations/progregs-bsc-computer-science-2021-22.pdf)
+- [Programme Specification](https://london.ac.uk/sites/default/files/programme-specifications/progspec-bsc-computer-science.pdf)
 - [Computer Science - Structure](https://london.ac.uk/computer-science-structure)

--- a/subreddit/progression.md
+++ b/subreddit/progression.md
@@ -13,7 +13,7 @@ Each Level is more advanced than the previous Level, hence there are *progressio
 
 > **Requirements to progress through the BSc**
 >
-> **5.6**
+> **5.11**
 >
 > To progress to FHEQ Level 5 modules, you must have:
 >
@@ -23,7 +23,7 @@ Each Level is more advanced than the previous Level, hence there are *progressio
 >
 > * registered for any Level 4 modules not yet attempted alongside your Level 5 modules, excluding any for which you have been awarded credit through recognition of prior learning
 
-Source: [Programme Regulations, Section 5.6, Page 12](https://london.ac.uk/sites/default/files/regulations/progregs-computer-science-2020-21.pdf)
+Source: [Programme Regulations, Section 5.11, Page 16](https://london.ac.uk/sites/default/files/regulations/progregs-bsc-computer-science-2021-22.pdf)
 
 ## Are all Level 4 modules offered every term?
 **No. The Discrete Mathematics (DM) and Computational Mathematics (CM) modules are only available on an alternating basis.** Discrete Mathematics is only available on the October (Fall) term, while Computational Mathematics is only available on the April (Spring) term.
@@ -139,7 +139,7 @@ You really don't need a schedule to not be progression-blocked, as long as you c
 * *[No longer at risk of being 'progression-blocked']*
 
 ## What about progression from Level 5 to Level 6? Or from Level 6 to Final Project?
-There is are separate sets of progression requirements which govern further progression into the degree programme. These rules can be found in the [Programme Regulations, Sections 5.6 and 5.8 (pages 12-13)](https://london.ac.uk/sites/default/files/regulations/progregs-computer-science-2020-21.pdf).
+There is are separate sets of progression requirements which govern further progression into the degree programme. These rules can be found in the [Programme Regulations, Sections 5.11 and 5.12 (pages 16-17)](https://london.ac.uk/sites/default/files/regulations/progregs-bsc-computer-science-2021-22.pdf).
 
 As these are more advanced topics that are only relevant to advanced students, they are out-of-scope for this guide. Students are encouraged to consult the Programme Regulations, and direct their questions to the private students-only Slack.
 
@@ -148,9 +148,9 @@ You may run into issues. You could potentially avoid being severely delayed [if 
 
 ## Conclusion and Further Resources
 
-- [General Regulations](https://london.ac.uk/sites/default/files/regulations/progregs-general-2020-2021.pdf)
-- [Programme Regulations](https://london.ac.uk/sites/default/files/regulations/progregs-computer-science-2020-21.pdf)
-- [Programme Specification](https://london.ac.uk/sites/default/files/programme-specifications/progspec-computer-science-2020-21.pdf)
+- [General Regulations](https://london.ac.uk/sites/default/files/regulations/general-regulations-2021-2022.pdf)
+- [Programme Regulations](https://london.ac.uk/sites/default/files/regulations/progregs-bsc-computer-science-2021-22.pdf)
+- [Programme Specification](https://london.ac.uk/sites/default/files/programme-specifications/progspec-bsc-computer-science.pdf)
 - [Computer Science - Structure](https://london.ac.uk/computer-science-structure)
 
 Thank you all for reading this guide to progression requirements within the University of London's BSc of Computer Science! If you have any questions, feel free to join us at the unofficial Discord server ([invitation link](https://discord.gg/GhRFG5X))!

--- a/subreddit/resources-links/links-discord-resources.md
+++ b/subreddit/resources-links/links-discord-resources.md
@@ -17,13 +17,13 @@ Admissions prospectus on the BSc Computer Science for interested students. A pol
 A high-level summary of the 22 modules and Final Project which makes up the Programme, seperated by Levels.
 :link: https://london.ac.uk/computer-science-structure
 
-**Programme Regulations (2020-2021)**
+**Programme Regulations (2021-2022)**
 The 'Bible' of the BSc Computer Science degree. _If you will only read one document from this section, read this one._ Contains almost every detail about specific workings and regulations.
-:page_facing_up: https://london.ac.uk/sites/default/files/regulations/progregs-computer-science-2020-21.pdf
+:page_facing_up: https://london.ac.uk/sites/default/files/regulations/progregs-bsc-computer-science-2021-22.pdf
 
-**Programme Specification (2020-2021)**
+**Programme Specification**
 A broad outline and overview of the structure and content of the degree, entry level qualifications, and learning outcomes.
-:page_facing_up: https://london.ac.uk/sites/default/files/programme-specifications/progspec-computer-science-2020-21.pdf
+:page_facing_up: https://london.ac.uk/sites/default/files/programme-specifications/progspec-bsc-computer-science.pdf
 
 :gb: **About the University of London** :gb:
 Links :link: and PDFs :page_facing_up: about the University of London in general, as well as resources for students.
@@ -38,7 +38,7 @@ Admissions prospectus about the University of London in general. A polished, inf
 
 **General Regulations**
 Handbook of rules and regulations governing the University of London _If you will only read one document from this section, read this one._ Contains almost every detail about specific workings and systems of the University of London.
-:page_facing_up: https://london.ac.uk/sites/default/files/regulations/progregs-general-2020-2021.pdf
+:page_facing_up: https://london.ac.uk/sites/default/files/regulations/general-regulations-2021-2022.pdf
 
 **Student's Guide**
 Guide for current students of the University of London. Includes information like how to get funding, online libraries, and support networks

--- a/subreddit/resources-links/links-reddit-sidebar-olddesign.md
+++ b/subreddit/resources-links/links-reddit-sidebar-olddesign.md
@@ -12,16 +12,16 @@
   Admissions prospectus on the BSc Computer Science for interested students. A polished, informative summary of the Programme.
 - [**Structure & Module Descriptions**](https://london.ac.uk/computer-science-structure)
   A high-level summary of the 22 modules and Final Project which makes up the Programme, seperated by Levels.
-- [**Programme Regulations (2020-2021)**](https://london.ac.uk/sites/default/files/regulations/progregs-computer-science-2020-21.pdf)
+- [**Programme Regulations (2021-2022)**](https://london.ac.uk/sites/default/files/regulations/progregs-bsc-computer-science-2021-22.pdf)
   The 'Bible' of the BSc Computer Science degree. _If you will only read one document from this section, read this one._ Contains almost every detail about specific workings and regulations.
-- [**Programme Specification (2020-2021)**](https://london.ac.uk/sites/default/files/programme-specifications/progspec-computer-science-2020-21.pdf)
+- [**Programme Specification**](https://london.ac.uk/sites/default/files/programme-specifications/progspec-bsc-computer-science.pdf)
   A broad outline and overview of the structure and content of the degree, entry level qualifications, and learning outcomes.
 
 ## About the University of London 🇬🇧
 
 - [**University of London Website**](https://london.ac.uk/) The official website of the University of London. Did you know that the University of London has been offering Distance-Learning programmes since the 19th century?
 - [**University of London Prospectus (2020)**](https://london.ac.uk/sites/default/files/prospectuses/GIP-2020.pdf) Admissions prospectus about the University of London in general. A polished, informative summary for the prospective student.
-- [**General Regulations**](https://london.ac.uk/sites/default/files/regulations/progregs-general-2020-2021.pdf) Handbook of rules and regulations governing the University of London _If you will only read one document from this section, read this one._ Contains almost every detail about specific workings and systems of the University of London.
+- [**General Regulations**](https://london.ac.uk/sites/default/files/regulations/general-regulations-2021-2022.pdf) Handbook of rules and regulations governing the University of London _If you will only read one document from this section, read this one._ Contains almost every detail about specific workings and systems of the University of London.
 - [**Student's Guide**](https://my.london.ac.uk/documents/10197/2676152/Student+Guide/07f72f0b-fd7d-cc23-603f-db6c31bfa5e2) Guide for current students of the University of London. Includes information like how to get funding, online libraries, and support networks
 - [**Student Terms and Conditions**](https://london.ac.uk/sites/default/files/governance/student-terms-and-conditions.pdf) Important legal contract which covers the consumer rights and legal protections for enrolled students. Includes information on refunds.
 - [**Table of Country Bands (for Tuition)**](https://london.ac.uk/sites/default/files/leaflets/country-bands.pdf) Tuition for the University of London is dependant on your 'Country Band'. Band A countries pay £400 GBP per module, while Band B countries pay £600 GBP per module.

--- a/subreddit/resources-links/links-reddit-sidebar-redesign.md
+++ b/subreddit/resources-links/links-reddit-sidebar-redesign.md
@@ -14,11 +14,11 @@ Admissions prospectus on the BSc Computer Science for interested students. A pol
 [**Structure & Module Descriptions**](https://london.ac.uk/computer-science-structure)
 A high-level summary of the 22 modules and Final Project which makes up the Programme, seperated by Levels.
 
-[**Programme Regulations (2020-2021)**](https://london.ac.uk/sites/default/files/regulations/progregs-computer-science-2020-21.pdf)
+[**Programme Regulations (2021-2022)**](https://london.ac.uk/sites/default/files/regulations/progregs-bsc-computer-science-2021-22.pdf)
 The 'Bible' of the BSc Computer Science degree. _If you will only read one document from this section, read this one._ Contains almost every detail about specific workings and regulations.
 https://london.ac.uk/sites/default/files/regulations/progregs-computer-science-2020-21.pdf
 
-[**Programme Specification (2020-2021)**](https://london.ac.uk/sites/default/files/programme-specifications/progspec-computer-science-2020-21.pdf)
+[**Programme Specification**](https://london.ac.uk/sites/default/files/programme-specifications/progspec-bsc-computer-science.pdf)
 A broad outline and overview of the structure and content of the degree, entry level qualifications, and learning outcomes.
 
 ## About the University of London 🇬🇧
@@ -31,7 +31,7 @@ The official website of the University of London. Did you know that the Universi
 [**University of London Prospectus (2020)**](https://london.ac.uk/sites/default/files/prospectuses/GIP-2020.pdf)
 Admissions prospectus about the University of London in general. A polished, informative summary for the prospective student.
 
-[**General Regulations**](https://london.ac.uk/sites/default/files/regulations/progregs-general-2020-2021.pdf)
+[**General Regulations**](https://london.ac.uk/sites/default/files/regulations/general-regulations-2021-2022.pdf)
 Handbook of rules and regulations governing the University of London _If you will only read one document from this section, read this one._ Contains almost every detail about specific workings and systems of the University of London.
 
 [**Student's Guide**](https://my.london.ac.uk/documents/10197/2676152/Student+Guide/07f72f0b-fd7d-cc23-603f-db6c31bfa5e2)

--- a/subreddit/resources-links/links-reddit-sticky.md
+++ b/subreddit/resources-links/links-reddit-sticky.md
@@ -30,11 +30,11 @@ Admissions prospectus on the BSc Computer Science for interested students. A pol
 ### [**Structure & Module Descriptions**](https://london.ac.uk/computer-science-structure)
 A high-level summary of the 22 modules and Final Project which makes up the Programme, seperated by Levels.
 
-### [**Programme Regulations (2020-2021)**](https://london.ac.uk/sites/default/files/regulations/progregs-computer-science-2020-21.pdf)
+### [**Programme Regulations (2021-2022)**](https://london.ac.uk/sites/default/files/regulations/progregs-bsc-computer-science-2021-22.pdf)
 The 'Bible' of the BSc Computer Science degree. *If you will only read one document from this section, read this one.* Contains almost every detail about specific workings and regulations.
 
 
-### [**Programme Specification (2020-2021)**](https://london.ac.uk/sites/default/files/programme-specifications/progspec-computer-science-2020-21.pdf)
+### [**Programme Specification**](https://london.ac.uk/sites/default/files/programme-specifications/progspec-bsc-computer-science.pdf)
 A broad outline and overview of the structure and content of the degree, entry level qualifications, and learning outcomes.
 
 ---
@@ -44,7 +44,7 @@ Links 🔗 and PDFs 📄 about the University of London in general, as well as r
 
 * [**University of London Website**](https://london.ac.uk/) The official website of the University of London. Did you know that the University of London has been offering Distance-Learning programmes since the 19th century?
 * [**University of London Prospectus (2020)**](https://london.ac.uk/sites/default/files/prospectuses/GIP-2020.pdf) Admissions prospectus about the University of London in general. A polished, informative summary for the prospective student.
-* [**General Regulations**](https://london.ac.uk/sites/default/files/regulations/progregs-general-2020-2021.pdf) Handbook of rules and regulations governing the University of London *If you will only read one document from this section, read this one.* Contains almost every detail about specific workings and systems of the University of London.
+* [**General Regulations**](https://london.ac.uk/sites/default/files/regulations/general-regulations-2021-2022.pdf) Handbook of rules and regulations governing the University of London *If you will only read one document from this section, read this one.* Contains almost every detail about specific workings and systems of the University of London.
 * [**Student's Guide**](https://my.london.ac.uk/documents/10197/2676152/Student+Guide/07f72f0b-fd7d-cc23-603f-db6c31bfa5e2) Guide for current students of the University of London. Includes information like how to get funding, online libraries, and support networks
 * [**Student Terms and Conditions**](https://london.ac.uk/sites/default/files/governance/student-terms-and-conditions.pdf) Important legal contract which covers the consumer rights and legal protections for enrolled students. Includes information on refunds.
 * [**List of Exam Centres (Worldwide)**](https://my.london.ac.uk/documents/10197/2926462/examcentres-worldwide2/659d044f-25c3-2a01-fd7e-0667e3d9e71a)

--- a/subreddit/uol-review.md
+++ b/subreddit/uol-review.md
@@ -122,7 +122,7 @@ Interested? Feel free to ask me any questions in this thread. AMA! :)
 ### Detailed Information
 
 - [Course Structure with List of Classes:](https://london.ac.uk/computer-science-structure) This is the official Course Structure, with information on all the individual semester-long classes, which compose the degree.
-- [Programme Specification (PDF):](https://london.ac.uk/sites/default/files/programme-specifications/progspec-computer-science-2020-21.pdf) This is the 'Bible' of the degree -- here are all the detailed rules and administrative guides. If you have detailed, specific questions about grade boundaries, retaking exams, et cetera -- this is where to look.
+- [Programme Specification (PDF):](https://london.ac.uk/sites/default/files/programme-specifications/progspec-bsc-computer-science.pdf) This is the 'Bible' of the degree -- here are all the detailed rules and administrative guides. If you have detailed, specific questions about grade boundaries, retaking exams, et cetera -- this is where to look.
 
 ### Unofficial Resources
 


### PR DESCRIPTION
## Update REPL with recent changes

> - Graduate Certificate and Graduate Diploma awards are due to launch in April 2022 and are
> now included
> - Requests for Recognition of Prior Learning are now permitted for Level 5 and Level 6
> modules
> - Progression from the Performance Based Admissions route to the full award (BSc) has been
> updated
> - Appendix D ‘Transferring from Computing Information Systems or Creative Computing’ has
> been added
> - The following modules will be assessed by coursework only Type III assessment:
> -- Virtual Reality [CM3025]
> -- Games Development [CM3030]