### PR TITLE
Added new bugs section for OOP Module

### DIFF
--- a/kinks/README.md
+++ b/kinks/README.md
@@ -4,6 +4,7 @@
 
 - [Table of contents](#table-of-contents)
 - [Kinks found in Level 4 modules](#kinks-found-in-level-4-modules)
+- [Kinks found in Level 5 modules](#kinks-found-in-level-5-modules)
 - [Note to future students](#note-to-future-students)
 
 ---
@@ -16,6 +17,11 @@
 - [Introduction to Programming I](../kinks/level-4/cm-1005-introduction-to-programming-i/README.md)
 - [Introduction to Programming II](../kinks/level-4/cm-1010-introduction-to-programming-ii/README.md)
 - [Web Development](../kinks/level-4/cm-1040-web-development/README.md)
+
+# Kinks found in Level 5 modules
+
+- [Databases, Networks and the Web](../kinks/level-5/cm-2040-databases-networks-and-the-web/README.md)
+- [Object Oriented Programming](../kinks/level-5/cm-2005-object-oriented-programming/README.md)
 
 As a great complimentary resource, don't forget to check out the `#bugs` channel on Slack.
 

--- a/kinks/level-5/cm-2005-object-oriented-programming/README.md
+++ b/kinks/level-5/cm-2005-object-oriented-programming/README.md
@@ -1,0 +1,37 @@
+
+# Table of contents
+
+- [Table of contents](#table-of-contents)
+- [Object Oriented Programming - Reported Problems](#object-oriented-programming---reported-problems)
+  - [Week 18](#week-18)
+    - [9.2 Adding a moveable playhead](#92-adding-a-moveable-playhead)
+      - [9.207 - Implement A Timer](#9207-Implement-a-timer)
+  - [Week 19](#week-19)
+    - [Vector Subscript Out of Range](#vector-subscript-out-of-range)
+
+# Object Oriented Programming - Reported Problems
+
+This page is about the [Object Oriented Programming module](../../../modules/level-5/cm-2005-object-oriented-programming/).
+
+## Week 18
+
+### 9.2 Adding a moveable playhead
+
+#### 9.207 Implement a timer
+
+_"There's a nasty bug in week 18 video 9.207. When you load a file the application will crash. After a bit of detective work it turns out that as the timer is being called before a file is loaded, the position is NaN (not a number). I found a simple fix for this: "_ - Jamie Jackson
+
+![Solution](https://github.com/world-class/binary-assets/blob/master/modules/cm2005-oop/bugs/bug_9.207.png?raw=true)
+
+## Week 19
+
+### 10.1 Starter Table Component
+
+#### "Vector Subscript Out of Range"
+
+"_If you try maximising the window you'll get a crash. Inspecting the error message it says vector subscript out of range. So I looked up the paintCell function in the juce API, it says in the description:_
+> Note that the rowNumber value may be greater than the number of rows in your list, so be careful that you don't assume it's less than getNumRows().
+
+_So a solution I came up with for the problem is to use getNumRows() and check if rowNum is less than it like in the image below._" - Jamie Jackson
+
+![Solution](https://github.com/world-class/binary-assets/blob/master/modules/cm2005-oop/bugs/bug_10.207.png?raw=true)

--- a/kinks/level-5/cm-2005-object-oriented-programming/README.md
+++ b/kinks/level-5/cm-2005-object-oriented-programming/README.md
@@ -34,4 +34,4 @@ _"There's a nasty bug in week 18 video 9.207. When you load a file the applicati
 
 _So a solution I came up with for the problem is to use getNumRows() and check if rowNum is less than it like in the image below._" - Jamie Jackson
 
-![Solution](https://github.com/world-class/binary-assets/blob/master/modules/cm2005-oop/bugs/bug_10.207.png?raw=true)
+![Solution](https://github.com/world-class/binary-assets/blob/master/modules/cm2005-oop/bugs/bug_10.107.png?raw=true)

--- a/modules/level-5/cm-2005-object-oriented-programming/README.md
+++ b/modules/level-5/cm-2005-object-oriented-programming/README.md
@@ -10,6 +10,7 @@
 - [Past exams](#past-exams)
 - [Syllabus](#syllabus)
 - [Resources](#resources)
+  - [Kinks to be aware of](#kinks-to-be-aware-of)
   - [Linux setup guide for OOP projects](#linux-setup-guide-for-oop-projects)
   - [Class diagram of starter code](#class-diagram-of-starter-code)
   - [Complementary learning](#complementary-learning)
@@ -67,6 +68,10 @@ Coursework only (Type II)
 ## Resources
 
 - :star: [Sourcetrail](https://www.sourcetrail.com) (Windows, macOS, Linux) - _"Free and open-source cross-platform source explorer"_. Supports C, C++, Java and Python.
+
+### Kinks to be aware of
+
+- [List of reported errors and bugs with the module](../../../kinks/level-5/cm-2005-object-oriented-programming/).
 
 ### Linux setup guide for OOP projects
 


### PR DESCRIPTION
### Added 'bugs' section for OOP module

   - Added a "kinks to be aware of" section for OOP module to document commonly reported bugs on Slack. This page is stored inside the kinks folder in the REPL inside relevant sub-folder.
   - Added a line of code linking the bug page to the main OOP module page
   - Updated the main kinks README.md to display the new section (also includes the DBNW bugs page, which was missing previously)

This update requires assets in the binary-assets repository, which includes a couple of images. I have create a new PR requesting to add them. [PR link here](https://github.com/world-class/binary-assets/pull/11)





