### PR TITLE
	Update OOP Bugs Document and General Format Maintenance

### DIFF
--- a/kinks/level-5/cm-2005-object-oriented-programming/README.md
+++ b/kinks/level-5/cm-2005-object-oriented-programming/README.md
@@ -1,8 +1,12 @@
+[Go back to the main page](../../../README.md)
 
 # Table of contents
 
 - [Table of contents](#table-of-contents)
 - [Object Oriented Programming - Reported Problems](#object-oriented-programming---reported-problems)
+  - [Week 14](#week-14)
+    - [7.5 Audio Playback - Files](#75-audio-playback---files)
+      - [7.504 Adding a File Chooser](#7504-adding-a-file-chooser)
   - [Week 18](#week-18)
     - [9.2 Adding a moveable playhead](#92-adding-a-moveable-playhead)
       - [9.207 - Implement A Timer](#9207-Implement-a-timer)
@@ -13,6 +17,48 @@
 
 This page is about the [Object Oriented Programming module](../../../modules/level-5/cm-2005-object-oriented-programming/).
 
+## Week 14
+
+### 7.5 Audio Playback - Files
+
+#### 7.504 Adding a File Chooser
+
+_"For those of you wondering how to get the file browser working (chooser.browseForFileToOpen does not exist any more) without changing the library preprocessor symbols - use the async version, e.g. like this:"_ - Matthias Truxa
+
+In `MainComponent.h` -> `private:`
+
+```C++
+juce::FileChooser chooser{ "Select a file..." };
+```
+
+In `MainComponent.cpp` -> `MainComponent::buttonClicked`
+
+```C++
+void MainComponent::buttonClicked(Button* button)
+{
+  if (button == &loadButton)
+    {
+    auto dlgFlags = 
+      juce::FileBrowserComponent::openMode | 
+      juce::FileBrowserComponent::canSelectFiles; 
+
+				this->chooser.launchAsync(dlgFlags, 
+						[this](const juce::FileChooser& chooser) 
+				{
+            player1.loadURL(chooser.getURLResult());
+				});
+
+        // juce::FileChooser chooser{ "Select a file..." };
+        // if (chooser.browseForFileToOpen())
+        // {
+        //     player1.loadURL(URL{ chooser.getResult() });
+        // }
+    }
+}
+```
+
+Note: There is another method where you can add `JUCE_MODAL_LOOPS_PERMITTED=1` to your JUCE preprocessors, but this method is not suggested as any changes you make to your preprocessor might not reflect in the graders' version. This might cause your project to not function as intended.
+
 ## Week 18
 
 ### 9.2 Adding a moveable playhead
@@ -21,7 +67,16 @@ This page is about the [Object Oriented Programming module](../../../modules/lev
 
 _"There's a nasty bug in week 18 video 9.207. When you load a file the application will crash. After a bit of detective work it turns out that as the timer is being called before a file is loaded, the position is NaN (not a number). I found a simple fix for this: "_ - Jamie Jackson
 
-![Solution](https://github.com/world-class/binary-assets/blob/master/modules/cm2005-oop/bugs/bug_9.207.png?raw=true)
+```C++
+void WaveformDisplay::setPositionRelative(double pos)
+{
+  if (pos != position && !isnan(pos))
+  {
+    position = pos;
+    repaint();
+  }
+}
+```
 
 ## Week 19
 
@@ -34,4 +89,12 @@ _"There's a nasty bug in week 18 video 9.207. When you load a file the applicati
 
 _So a solution I came up with for the problem is to use getNumRows() and check if rowNum is less than it like in the image below._" - Jamie Jackson
 
-![Solution](https://github.com/world-class/binary-assets/blob/master/modules/cm2005-oop/bugs/bug_10.107.png?raw=true)
+```C++
+void PlaylistComponent::paintCell(juce::Graphics& g, int rowNumber, int columnId, int width, int height, bool rowIsSelected)
+{
+  if (rowNumber < getNumRows())
+  {
+    g.drawText(trackTitles[rowNumber], 2, 0, width -4, height, juce:Justification::centredleft, true);
+  }
+}
+```

--- a/kinks/level-5/cm-2040-databases-networks-and-the-web/README.md
+++ b/kinks/level-5/cm-2040-databases-networks-and-the-web/README.md
@@ -1,10 +1,10 @@
 [Go back to the main page](../../../README.md)
 
-### Table of contents
+# Table of contents
 
 - [Unable to generate a link for the midterm](#unable-to-generate-a-link-for-the-midterm)
 
----
+# Databases, Networks and the Web - Reported problems
 
 ## Unable to generate a link for the midterm
 


### PR DESCRIPTION
## Update OOP Bugs Document and General Format Maintenance

This pull request indexes new bugs to the OOP/Kinks to be aware of sub-section along with some minor format corrections.
 - This sub-section previously used images from REPL/binary-assets. They have now been replaced by code-blocks for ease of access.
 - Created a PR in REPL/Binary-Assets to remove the bugs directory. The removal of this folder will not affect the document in any way. [PR link](https://github.com/world-class/binary-assets/pull/12/commits)
 - Added "Return to Home Page" link to Kinks/Level-5/OOP
 - Updated Kinks/Level-5/DBNW to reflect format in other pages
 - Indexed another bug found in the module