### PR TITLE
add the 'LFD121' course as a resource on secure coding practices

### DIFF
--- a/modules/level-5/cm-2010-software-design-and-development/README.md
+++ b/modules/level-5/cm-2010-software-design-and-development/README.md
@@ -78,3 +78,7 @@ One two hour unseen written examination and coursework (Type I)
 
 - [Python] [Cohesion and coupling: write BETTER PYTHON CODE Part 1](https://www.youtube.com/watch?v=eiDyK_ofPPM) - ArjanCodes.
   - [Full playlist](https://www.youtube.com/playlist?list=PLC0nd42SBTaNuP4iB4L6SJlMaHE71FG6N) includes topics about dependency inversion/injection, design patterns, exception handling, inheritance, composition and more.
+
+## Secure coding practices
+- [Developing Secure Software (LFD121)](https://training.linuxfoundation.org/training/developing-secure-software-lfd121/) - The Linux Foundation. 
+  * This free course covers the same topics as the 'secure coding' section of the module in more depth along with other related topics. The course is heavily based on the reading of the mid-term assignment '_[Secure Programming HOWTO - Creating Secure Software](https://dwheeler.com/secure-programs/)_' as David Wheeler is the author of both materials.


### PR DESCRIPTION
This pull request is about:

* [ ] Fixing a bug.
* [ ] Updating documentation.
* [ ] Changing some functionality.
* [x] Other (please explain). - Adding a complementary resource for the cm-2010 module

The '[Developing Secure Software (LFD121)](https://training.linuxfoundation.org/training/developing-secure-software-lfd121/)'  course covers the same topics as the 'secure coding' section of the module in more depth along with other related topics.  I think students would benefit greatly from obtaining this training both for their studies and for their professional development.