### PR TITLE
Fix layout breaking due to long URL

### DIFF
--- a/faq/README.md
+++ b/faq/README.md
@@ -549,9 +549,8 @@ Some of the questions that can be answered by reading the programme regulations:
 
 > In one UoL's correspondence it said that we would need to reach out to our professor if we wanted to monetize it. How would we go about that for this degree being online?
 
-The section of the University’s Intellectual Property Rights Policy that specifically addresses your question is Part E. Please see [https://london.ac.uk/sites/default/files/governance/intellectualpropertypolicy.pdf](https://london.ac.uk/sites/default/files/governance/intellectualpropertypolicy.pdf).
-
-If you have any specific queries about something you have created which you are interested in publishing, please contact us via the support email <BscCs-support@london.ac.uk> and we can look into this further for you.
+- The section of the University’s Intellectual Property Rights Policy that specifically addresses your question is Part E. Please see [https://london.ac.uk/sites/default/files/governance/intellectualpropertypolicy.pdf](https://london.ac.uk/sites/default/files/governance/intellectualpropertypolicy.pdf).
+- If you have any specific queries about something you have created which you are interested in publishing, please contact us via the support email <BscCs-support@london.ac.uk> and we can look into this further for you.
 
 ### Are there opportunities for students to gain some form of work experience in the industry or even undergo internships during the course
 


### PR DESCRIPTION
### Background
- https://github.com/world-class/REPL/issues/276

### This pull request is about:
* [x] Fixing a bug.
* [ ] Updating documentation.
* [ ] Changing some functionality.
* [ ] Other (please explain).

### The approach I took to solve the issue
- By making the sentences bulleted, the style **would** be fixed.
- Also, there is another approach that uses `overflow-wrap: anywhere` to a-link.
  - However, I didn't choose the way because of the below reasons:
    - it has too big an impact
    - the overall REPL seems bulleted but the problem sentences didn't.

### Caveats
- Sorry, I haven't confirmed this change works because of the difficulty of building assets in my PC.
  - I installed jekyll and other plugins, and tried to work it by `bundle ex jekyll [build | serve]`.
  - Jekyll ran locally, however, the markdown file was not styled properly and I gave up.