### PR TITLE
Fix layout breaking with replacing the long URL with its title

### DIFF
--- a/faq/README.md
+++ b/faq/README.md
@@ -549,7 +549,7 @@ Some of the questions that can be answered by reading the programme regulations:
 
 > In one UoL's correspondence it said that we would need to reach out to our professor if we wanted to monetize it. How would we go about that for this degree being online?
 
-- The section of the University’s Intellectual Property Rights Policy that specifically addresses your question is Part E. Please see [https://london.ac.uk/sites/default/files/governance/intellectualpropertypolicy.pdf](https://london.ac.uk/sites/default/files/governance/intellectualpropertypolicy.pdf).
+- The section of the University’s Intellectual Property Rights Policy that specifically addresses your question is Part E. Please see [University of London – Policy on Intellectual Property Rights](https://london.ac.uk/sites/default/files/governance/intellectualpropertypolicy.pdf).
 - If you have any specific queries about something you have created which you are interested in publishing, please contact us via the support email <BscCs-support@london.ac.uk> and we can look into this further for you.
 
 ### Are there opportunities for students to gain some form of work experience in the industry or even undergo internships during the course


### PR DESCRIPTION
### Background
- https://github.com/world-class/REPL/issues/276
- https://github.com/world-class/REPL/pull/277
  - this didn't work

### This pull request is about:
* [x] Fixing a bug.
* [ ] Updating documentation.
* [ ] Changing some functionality.
* [ ] Other (please explain).

### The approach I took to solve the issue
- This PR replaces the URL with its title to solve the issue.
  - It solves the length problem and is also human-friendly.
- I guess the reason why the style was broken is the URL does not have the point to separate (= break) words.

### Local testing on my browser
![2023-06-12 18 33 28](https://github.com/world-class/REPL/assets/29012724/ee779fc4-4319-4503-a484-8bc213207227)