### PR TITLE
Add step to escalate a support issue to a complaint

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,8 @@ relevant topic for the final project.</p>
 <li><a href="https://my.london.ac.uk/">General enquiries <strong>for students</strong></a>: Click <em>"Ask a question"</em> in <a href="https://my.london.ac.uk/">the portal</a> or, equivalently, write to <a href = "mailto:BScCS-support@london.ac.uk">BScCS-support@london.ac.uk</a>.</li>
 <li>Reach out by phone (<strong>service not available during COVID-19</strong>): <code>+44 (0)20 7862 8000</code> (general), <code>+44 (0)20 7862 5766</code> (specific to this degree), <code>+44 (0)20 7862 8368</code> (fees office).</li>
 <li><a href="https://london.kb.help/">Student Advice Center</a>: knowledge base for frequently asked questions.</li>
+<li>To escalate an issue, create an official <a href="https://www.london.ac.uk/current-students/student-policies/complaints-appeals-procedure">Student Complaint</a> by emailing <a href = "mailto:a&c@london.ac.uk">A&C@london.ac.uk</a> and asking for a stage 2 complaint form, <strong>clearly outlining the problem</strong>.
+</li>
 </ul>
 
 </details>


### PR DESCRIPTION
This pull request is about:

* [ ] Fixing a bug.
* [x] Updating documentation.
* [ ] Changing some functionality.
* [ ] Other (please explain).

I suggest adding the stage 2 student complaint procedure to the "Contacting UoL" page, as an escalation step where students have failed to receive a reasonable support. 

This is in response to one student asking on Slack what they should do if UoL deferred their final exam for their final project without informing them, and they have already waited for months for a response.