### PR TITLE
Update the link to the genetic algorithms book as a new edition was published

### DIFF
--- a/modules/level-6/cm-3020-artificial-intelligence/README.md
+++ b/modules/level-6/cm-3020-artificial-intelligence/README.md
@@ -63,5 +63,4 @@ One two-hour unseen written examination and coursework (Type I)
 - [Deep RL Course](https://huggingface.co/learn/deep-rl-course/unit0/introduction). - Hugging Face
 
 ### Genetic Algorithms:
-- [Hands-On Genetic Algorithms with Python](https://learning.oreilly.com/library/view/hands-on-genetic-algorithms/9781838557744/). - Eyal Wirsansky
-  - _Note: this link, http://elib.zib.de/pub/mp-testdata/tsp/tsplib/tsp/, is mentioned in the book but it is currently broken, access the archived page(s) here instead: [https://web.archive.org/web/20220303144342/http://elib.zib.de/pub/mp-testdata/tsp/tsplib/tsp/](https://web.archive.org/web/20220303144342/http://elib.zib.de/pub/mp-testdata/tsp/tsplib/tsp/)_
+- [Hands-On Genetic Algorithms with Python - Second Edition](https://learning.oreilly.com/library/view/hands-on-genetic-algorithms/9781805123798/). - Eyal Wirsansky


### PR DESCRIPTION
Since the second edition of the genetic algorithms book was published, the link was updated accordingly. The links to Web Archive that I had added previously are no longer necessary because the links present in the new edition are valid.

This pull request is about:

* [ ] Fixing a bug.
* [x] Updating documentation.
* [ ] Changing some functionality.
* [ ] Other (please explain).
