### PR TITLE
chore: update agile software project module to be withdrawn by UoL

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ A twist on the use of **REPL**, which stands for _read–eval–print loop_ in c
 </thead>
 <tbody>
 <tr>
-<td><a href="modules/level-5/cm-2020-agile-software-projects">Agile Software Projects</a></td>
+<td><a href="modules/level-5/cm-2020-agile-software-projects">Agile Software Projects</a><br /><strong>*will be withdrawn in October 2026. See Note below.</strong></td>
 <td><strong>ASP</strong></td>
 <td><strong>CM2020</strong></td>
 <td>No</td>
@@ -278,6 +278,10 @@ A twist on the use of **REPL**, which stands for _read–eval–print loop_ in c
 </tbody>
 </table>
 </div>
+
+> Note: **Agile Software Projects CM2020, will be withdrawn in October 2026.** If you wish to study Agile Software Projects and have not yet registered on this module, your last opportunity to study this module will be in the **October 2024** session. The final assessment retake opportunity for this module will be October 2026.
+> <!-- intentionally empty -->
+> The **Professional Practice for Computer Scientists** module will be introduced in place of **Agile Software Projects CM2020** and will run for the first time in April 2025.
 
 </details>
 

--- a/modules/level-5/cm-2020-agile-software-projects/README.md
+++ b/modules/level-5/cm-2020-agile-software-projects/README.md
@@ -14,9 +14,15 @@
   - [Complementary learning](#complementary-learning)
   - [:heart: Notes](#heart-notes)
   - [Textbooks listed for this module](#textbooks-listed-for-this-module)
-    - [Further reading recommended in Interaction Design: Beyond Human-Computer Interaction, John Wiley & Sons](#further-reading-recommended-in-interaction-design-beyond-human-computer-interaction-john-wiley--sons)
+    - [Further reading recommended in Interaction Design: Beyond Human-Computer Interaction, John Wiley \& Sons](#further-reading-recommended-in-interaction-design-beyond-human-computer-interaction-john-wiley--sons)
 
 ---
+
+<br />
+
+> Note: **Agile Software Projects CM2020, will be withdrawn in October 2026.** If you wish to study Agile Software Projects and have not yet registered on this module, your last opportunity to study this module will be in the **October 2024** session. The final assessment retake opportunity for this module will be October 2026.
+> <!-- intentionally empty -->
+> The **Professional Practice for Computer Scientists** module will be introduced in place of **Agile Software Projects CM2020** and will run for the first time in April 2025.
 
 ## Agile Software Projects
 


### PR DESCRIPTION
This pull request is about:

* [ ] Fixing a bug.
* [x] Updating documentation.
* [ ] Changing some functionality.
* [ ] Other (please explain).

This documentation change highlights the withdrawal of Agile Software Projects CM2020 module in October 2026, as notified in this [link](https://www.coursera.org/learn/london-cs-orientation/supplement/IAZCe/course-registration).