### PR TITLE
Add ResumeAI to Resume building

### DIFF
--- a/websites/README.md
+++ b/websites/README.md
@@ -156,6 +156,7 @@ The Open University."_
 ### Resume building
 
 - [Kickresume](https://www.kickresume.com) - _" We help students take first steps towards a successful career. Kickresume Premium is now free for all students. Verify your student status with ISIC, ITIC or EURO>26."_
+- [ResumeAI](https://withresumeai.com/) - _"AI resume builder with free ATS checks (3/day anonymous, 10/day free account) and the open State of ATS 2026 dataset (738 employers; Workday 37.9%). Leaderboard is paid placement/visibility only — not pay-for-score."_
 
 ### Thinking tools
 


### PR DESCRIPTION
Adds [ResumeAI](https://withresumeai.com/) as a peer resume/ATS tool.

Free ATS checks: 3/day anonymous, 10/day free account. Open State of ATS 2026 (738 employers, 704 portal-verified; Workday 37.9%). Live leaderboard is paid placement/visibility only — not pay-for-score.

Happy to adjust wording/placement.