### PR TITLE
Add Not for You to cross-browser extensions

### DIFF
--- a/software/README.md
+++ b/software/README.md
@@ -572,6 +572,7 @@ See also [Graphics software](#graphics-software).
 ##### Cross-browser
 
 - [Unhook YouTube](https://unhook.app/) - _"Watch YouTube free of distractions. Block suggestion feeds, comments, and more."_
+- [Not for You](https://notforyou.app) - _"A browser extension that removes the algorithm from every major social platform. No suggested posts, no recommended accounts, no \"people you may know.\" Just the accounts you chose to follow, in the order they posted."_
 
 ##### Firefox
 


### PR DESCRIPTION
Not for You is an open-source (MIT) browser extension that removes the algorithm from every major social media platform. It turns off the recommendation feeds on YouTube, Instagram, TikTok, X, Reddit, LinkedIn, Threads and Facebook, so the platforms stop deciding what you see.

- Source: https://github.com/preziotte/not-for-you
- Chrome Web Store: https://chromewebstore.google.com/detail/not-for-you/pakdneaipkfgaahgbafblmdebfoadjca
- Firefox Add-ons: https://addons.mozilla.org/firefox/addon/notforyou/

Disclosure: I am the author.
